### PR TITLE
Fix typos

### DIFF
--- a/.gitlab/issue_templates/BrokenFeed.md
+++ b/.gitlab/issue_templates/BrokenFeed.md
@@ -8,7 +8,7 @@ example.com/podcast
 
 **Detailed description of the issue**
 
-Would be helpfull if error messages where included from stderr.
+Would be helpful if error messages where included from stderr.
 If you are not sure how to do it, feel free to ask and we will walk you through it!
 
 Some common cases might be:

--- a/.gitlab/issue_templates/Epic.md
+++ b/.gitlab/issue_templates/Epic.md
@@ -20,7 +20,7 @@ or
 
 # Requirements
 <!--
-What does the solution needs to ensure for being succesful?
+What does the solution needs to ensure for being successful?
 
 For example:
 * Work on small form factors and touch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed:
 - Fix the wrong User-Agent header being sent World/podcasts!207
-- Make newlines display in episode descritpions display correctly World/podcasts!206
+- Make newlines display in episode descriptions display correctly World/podcasts!206
 
 ## [0.5.0-beta] - 2021-08-20
 
@@ -95,7 +95,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed:
  - Fix phantom window World/podcasts!128
  - <enter> to add feed World/podcasts!130
- - Prevent simultanious refreshes World/podcasts!133
+ - Prevent simultaneous refreshes World/podcasts!133
  - Fix buttons in speed menu World/podcasts!134
  - Internationalisation fixes
 
@@ -113,7 +113,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Improved integration of cargo and meson World/podcasts!94
 - Refactored some macros for error handling World/podcasts!82
 - Refactored the handling of styling changes World/podcasts!119
-- Updated the icon to better match the HIG guidlines World/podcasts#102
+- Updated the icon to better match the HIG guidelines World/podcasts#102
 - Made Podcasts use a GtkApplication subclass World/podcasts!113
 - Updated the MPRIS permissions in order to remove a sandbox hole World/podcasts!124
 - Bumped gtk and libhandy minimum versions
@@ -141,7 +141,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - The applciation will no longer scale below 360p in width 1933c79f7a87d8261d91ca4e14eb51c1ddc66624
 - Update to the latest HIG 5050dda4d2f75b706842de8507d115dd5a1bd0a9
 - Chris, @brainblasted, upgraded hyper to 0.12, this brings openssl 1.1 support !75
-- Pipeline backend is now completly migrated to tokio-runtime 0887789f5e653dd92ad397fb39561df6dffcb45c
+- Pipeline backend is now completely migrated to tokio-runtime 0887789f5e653dd92ad397fb39561df6dffcb45c
 - Resume playing an episode will attempt to rewind the track only if more than a minute has passed since the last pause !76
 
 ### Fixed:
@@ -180,19 +180,19 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [OARS](https://hughsie.github.io/oars/) Tags where added for compatibility with Store clients b0c94dd9
 - Daniel added support for Translations !46
 - Svitozar Cherepii(@svito) created a [wiki page](https://wiki.gnome.org/Apps/Podcasts) 70e79e50
-- Libhandy was added as a dependancy #70
+- Libhandy was added as a dependency #70
 - Development builds can now be installed in parallel with stable builds !64
 
 ### Changed:
 - The update indication was moved to an In-App notification #72
 - The app icon's accent color was changed from orange to red 0dfb4859
-- The stack switcher in the Headerbar is now insesitive on Empty Views !63
+- The stack switcher in the Headerbar is now insensitive on Empty Views !63
 
 ### Fixed:
 - Improved handling of HTTP redirections #64 !61 !62
 - Fixed a major performance regression when loading show covers !67
-- More refference cycles have been fixed !59
-- OPML import dialog now exits properly and no longer keeps the application from shuting down !65
+- More reference cycles have been fixed !59
+- OPML import dialog now exits properly and no longer keeps the application from shutting down !65
 - Update action is disabled if there isn't something to update #71
 
 ### Translations:
@@ -210,10 +210,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed:
 - `SendCell` crate was replaced with `Fragile`. (Jorda Petridis) 838320785ebbea94e009698b473495cfec076f54
-- Update dependancies (Jorda Petridis) 91bea8551998b16e44e5358fdd43c53422bcc6f3
+- Update dependencies (Jorda Petridis) 91bea8551998b16e44e5358fdd43c53422bcc6f3
 
 ### Fixed:
-- Fix more refference cycles. (Jorda Petridis) 3496df24f8d8bfa8c8a53d8f00262d42ee39b41c
+- Fix more reference cycles. (Jorda Petridis) 3496df24f8d8bfa8c8a53d8f00262d42ee39b41c
 - Actually fix cargo-vendor (Jorda Petridis)
 
 ## [0.4.3] - 2018-07-27
@@ -238,7 +238,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Custom icons for the fast-forward and rewind actions in the Player were added. (Tobias Bernard) e77000076b3d78b8625f4c7ef367376d0130ece6
 - Hicolor and symbolic icons for the Application. (Tobias Bernard and Sam Hewitt) edae1b04801dba9d91d5d4145db79b287f0eec2c
 - Basic prefferences dialog (Zander Brown). [34](https://gitlab.gnome.org/World/podcasts/merge_requests/34)
-- Dbus service preperation. Not used till the MPRIS2 integration has landed. (Zander Brown) [42](https://gitlab.gnome.org/World/podcasts/merge_requests/42)
+- Dbus service preparation. Not used till the MPRIS2 integration has landed. (Zander Brown) [42](https://gitlab.gnome.org/World/podcasts/merge_requests/42)
 - Episodes and Images will only get drawn when needed. Big Performance impact. (Jordan Petridis) [43](https://gitlab.gnome.org/World/podcasts/merge_requests/43)
 
 ### Changed:
@@ -266,13 +266,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - The `EpisdeWidget` was refactored.
 [!38](https://gitlab.gnome.org/World/podcasts/merge_requests/38)
 - `EpisdeWidget`'s progressbar was changed to be non-blocking and should feel way more responsive now. 9b0ac5b83dadecdff51cd398293afdf0d5276012
-- An embeded audio player was implemented!
+- An embedded audio player was implemented!
 [!40](https://gitlab.gnome.org/World/podcasts/merge_requests/40)
 - Various Database changes.
 [!41](https://gitlab.gnome.org/World/podcasts/merge_requests/41)
 
 ### Fixed:
-- Fixed a bug whre the about dialog would be unclosable. (ZanderBrown) [!37](https://gitlab.gnome.org/World/podcasts/merge_requests/37)
+- Fixed a bug where the about dialog would be unclosable. (ZanderBrown) [!37](https://gitlab.gnome.org/World/podcasts/merge_requests/37)
 
 ## [0.3.4] - 2018-05-20
 ### Fixed:
@@ -285,9 +285,9 @@ not being able to access any file.
 - ShowsView now rembmers the vertical alignment of the scrollbar between refreshes. 4d2b64e79d8518454b3677612664cd32044cf837
 
 ### Changed:
-- Minimum `rustc` version requirment was bumped to `1.26`
+- Minimum `rustc` version requirement was bumped to `1.26`
 - Some animations should be smoother now. 7d598bb1d08b05fd5ab532657acdad967c0afbc3
-- InAppNotification now can be used to propagate some erros to the user. 7035fe05c4741b3e7ccce6827f72766226d5fc0a and 118dac5a1ab79c0b4ebe78e88256a4a38b138c04
+- InAppNotification now can be used to propagate some errors to the user. 7035fe05c4741b3e7ccce6827f72766226d5fc0a and 118dac5a1ab79c0b4ebe78e88256a4a38b138c04
 
 ### Fixed:
 - Fixed a of by one bug in the `ShowsView` where the last show was never shown. bd12b09cbc8132fd39a266fd091e24bc6c3c040f
@@ -297,18 +297,18 @@ not being able to access any file.
 - Vies now have a new fancy scrolling animation when they are refereshed.
 
 ### Changed:
-- Downlaoding and loading images now is done asynchronously and is not blocking programs execution.
+- Downloading and loading images now is done asynchronously and is not blocking programs execution.
 [#7](https://gitlab.gnome.org/World/podcasts/issues/7)
 - Bold, italics links and some other `html` tags can now be rendered in the Show Description.
 [#25](https://gitlab.gnome.org/World/podcasts/issues/25)
 - `Rayon` Threadpools are now used instead of unlimited one-off threads.
-- `EpisdeWidget`s are now loaded asynchronously accross views.
+- `EpisdeWidget`s are now loaded asynchronously across views.
 - `EpisodeWidget`s no longer trigger a `View` refresh for trivial stuff 03bd95184808ccab3e0ea0e3713a52ee6b7c9ab4
 - `ShowWidget` layout was changed 9a5cc1595d982f3232ee7595b83b6512ac8f6c88
 - `ShowWidget` Description is inside a scrolled window now
 
 ### Fixed:
-- `EpisodeWidget` Height now is consistent accros views [#57](https://gitlab.gnome.org/World/podcasts/issues/57)
+- `EpisodeWidget` Height now is consistent across views [#57](https://gitlab.gnome.org/World/podcasts/issues/57)
 - Implemented a tail-recursion loop to follow-up when a feed redirects to another url. c6a24e839a8ba77d09673f299cfc1e64ba7078f3
 
 ### Removed:
@@ -330,7 +330,7 @@ not being able to access any file.
 ### Changed:
 - EpisdeWidget has been reimplemented as a compile time state machine.
 [!18](https://gitlab.gnome.org/World/podcasts/merge_requests/18)
-- Content Views no longer scroll horizontally when shrunk bellow their minimum size.
+- Content Views no longer scroll horizontally when shrunk below their minimum size.
 [#35](https://gitlab.gnome.org/World/podcasts/issues/35)
 - Some requests now use the Tor Browser's user agent. (Rowan Lewis)
 [#53](https://gitlab.gnome.org/World/podcasts/issues/53)

--- a/podcasts-data/src/models/episode.rs
+++ b/podcasts-data/src/models/episode.rs
@@ -271,7 +271,7 @@ impl EpisodeWidgetModel {
         self.show_id
     }
 
-    /// Sets the `played` value with the current `epoch` timestap and save it.
+    /// Sets the `played` value with the current `epoch` timestamp and save it.
     pub fn set_played_now(&mut self) -> Result<(), DataError> {
         let epoch = Utc::now().timestamp() as i32;
         self.set_played(Some(epoch));

--- a/podcasts-data/src/models/source.rs
+++ b/podcasts-data/src/models/source.rs
@@ -154,7 +154,7 @@ impl Source {
     // 304: Up to date Feed, checked with the Etag
     // 307: Temporary redirect of the url
     // 308: Permanent redirect of the url
-    // 401: Unathorized
+    // 401: Unauthorized
     // 403: Forbidden
     // 408: Timeout
     // 410: Feed deleted

--- a/podcasts-gtk/resources/org.gnome.Podcasts.appdata.xml.in.in
+++ b/podcasts-gtk/resources/org.gnome.Podcasts.appdata.xml.in.in
@@ -33,7 +33,7 @@
         </p>
         <ul>
           <li>Render lists in episode descriptions.</li>
-          <li>Avoid reduntant network request for the mpris cover art.</li>
+          <li>Avoid redundant network request for the mpris cover art.</li>
         </ul>
       </description>
     </release>
@@ -61,7 +61,7 @@
     <release version="0.4.8" date="2020-07-09">
      <description>
         <p>
-            Another Incremental relase, bringing more quality of life changes, bugfixes and continuing to improves adaptiveness of the application.
+            Another Incremental release, bringing more quality of life changes, bugfixes and continuing to improves adaptiveness of the application.
             Most notable is the addition of a "Now Playing" widget and the new 1.75 and 2.0 playback speed options.
         </p>
       </description>

--- a/podcasts-gtk/src/utils.rs
+++ b/podcasts-gtk/src/utils.rs
@@ -340,7 +340,7 @@ pub(crate) fn set_image_from_path(image: &gtk::Image, show_id: i32, size: u32) -
 
     // Check if there's an active download about this show cover.
     // If there is, a callback will be set so this function will be called again.
-    // If it fails another download will be scheduled. WTF??? how is this not downlaoding infinitly
+    // If it fails another download will be scheduled. WTF??? how is this not downloading infinitely
     if let Ok(guard) = COVER_DL_REGISTRY.read() {
         if guard.contains(&show_id) {
             let callback = clone!(@weak image => @default-return glib::Continue(false), move || {

--- a/podcasts-gtk/src/widgets/player.rs
+++ b/podcasts-gtk/src/widgets/player.rs
@@ -940,7 +940,7 @@ impl PlayerWrapper {
             .player
             .connect_end_of_stream(clone!(@strong sender, @strong weak => move |_| {
                 if let Some(player_widget) = weak.get().upgrade() {
-                    // write postion to db
+                    // write position to db
                     player_widget.borrow_mut().info.ep.as_mut().map(|ep| {
                         ep.set_play_position(0)?;
                         ep.set_played_now()?;

--- a/release_process.md
+++ b/release_process.md
@@ -1,4 +1,4 @@
-## Podcasts release proccess
+## Podcasts release process
 
 * Ensure there was a post-release version bump last time
 * Update CHANGELOG.md

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -8,7 +8,7 @@ set -x
 export CARGO_TARGET_DIR="$1/target/"
 export CARGO_HOME="$CARGO_TARGET_DIR/cargo-home"
 
-# If this is run inside a flatpak envrironment, append the export the rustc
+# If this is run inside a flatpak environment, append the export the rustc
 # sdk-extension binaries to the path
 if [ -f "/.flatpak-info" ]
 then


### PR DESCRIPTION
Found via `codespell -S po,*.xml -L crate,evey,nin,trough`